### PR TITLE
Updates to aid testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.idea/libraries
 .DS_Store
 /build
+AndroidKeystoreWipeTest.iml
+app/app.iml

--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@
 Simple app to test android keystore wiping
 
 Accompanies [a blog post I have written](http://systemdotrun.blogspot.co.uk/2015/02/android-security-forgetful-keystore.html)
+
+
+#Steps to Test keystore behaviour
+
+Note to switch lock type back to none, you'll have to remove device encryption, any user installed certificates i.e Charles Proxy root cert, and remove any device admins. Also once a keypair has been generated the system will not let you revert to NONE (regardless of if the KeyStore is encrypted or not) unless the app has been deleted / the pair removed.
+
+1. Set device lock to none
+2. Install this app
+3. Generate Key
+4. Verify key can be read (should show green bg)
+5. Change System lock type - Note which lock type going from and to
+6. Open app and record findings i.e T = the key can be read (green bg) or **F** if the key cannot be loaded (red bg).
+
+
+Repeat steps 3 to 6 for switching between different device lock types.
+
+Record them in using this markdown template, then you could send a PR or create issue with details on https://github.com/doridori/doridori.github.io
+Some tests will be N/A for example you cannot create a keystore entry with `setEncryptionRequired()` if device lock is **None**. You can try but you IllegalStateException.
+
+
+Blank table
+
+| to ↓        from > | NONE | PIN | PASS | PATTERN |
+|--------------------|------|-----|------|---------|
+| NONE               |      |     |      |         |
+| PIN                |      |     |      |         |
+| PASS               |      |     |      |         |
+| PATTERN            |      |     |      |         |
+
+
+Note: Testing with `setEncryptionRequired()` requires the device have a pin/password therefore the None column will be N/A.   

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "keystoretest.com.keystoretest"
         minSdkVersion 18
-        targetSdkVersion 18
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -21,5 +21,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.2'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "keystoretest.com.keystoretest"

--- a/app/src/main/java/keystoretest/com/keystoretest/MainActivity.java
+++ b/app/src/main/java/keystoretest/com/keystoretest/MainActivity.java
@@ -1,9 +1,10 @@
 package keystoretest.com.keystoretest;
 
-import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
+import android.content.Intent;
 import android.graphics.Color;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -13,98 +14,103 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 
-public class MainActivity extends Activity
-{
+public class MainActivity extends AppCompatActivity {
     public static final String ALIAS = "TestKeyAlias";
 
 
     private TextView status;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState)
-    {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        status = (TextView)findViewById(R.id.status);
+        status = (TextView) findViewById(R.id.status);
+    }
+
+
+    public void openSettings() {
+        Intent intent =
+                new Intent(DevicePolicyManager.ACTION_SET_NEW_PASSWORD);
+        startActivity(intent);
     }
 
     @Override
-    protected void onStart()
-    {
+    protected void onStart() {
         super.onStart();
         updateStatus("start", true);
         checkIfAliasExists();
     }
 
     @Override
-    protected void onPause()
-    {
+    protected void onPause() {
         super.onPause();
 
     }
 
     @Override
-    protected void onStop()
-    {
+    protected void onStop() {
         super.onStop();
         updateStatus("stop", false);
         System.exit(0);
     }
 
-    private void checkIfAliasExists()
-    {
-        try
-        {
+    private void checkIfAliasExists() {
+        try {
             boolean aliasInKeyStore = SecretKeyWrapper.isAliasInKeystore(ALIAS);
             updateStatus("Alias in keystore:" + aliasInKeyStore, aliasInKeyStore);
 
-            if(aliasInKeyStore)
-            {
+            if (aliasInKeyStore) {
                 //test key can be read
                 new SecretKeyWrapper(this, ALIAS);
                 updateStatus("Key can be read", true);
             }
-        }
-        catch (GeneralSecurityException e)
-        {
+        } catch (GeneralSecurityException e) {
             updateStatus(e.getMessage(), false);
             e.printStackTrace();
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             updateStatus(e.getMessage(), false);
             e.printStackTrace();
         }
     }
 
-    public void generateClicked(View view)
-    {
-        try
-        {
+    public void generateClicked(View view) {
+        try {
             SecretKeyWrapper mSecretKeyWrapper = new SecretKeyWrapper(this, ALIAS);
             updateStatus("Pair generated with alias!", true);
-        }
-        catch (GeneralSecurityException e)
-        {
+        } catch (GeneralSecurityException e) {
             e.printStackTrace();
             updateStatus(e.getMessage(), false);
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             e.printStackTrace();
             updateStatus(e.getMessage(), false);
         }
 
     }
 
-    private void updateStatus(String string, boolean good)
-    {
-        status.setText(status.getText()+"\n"+string);
+    private void updateStatus(String string, boolean good) {
+        status.setText(status.getText() + "\n" + string);
         setStatusColor(good ? Color.GREEN : Color.RED);
     }
 
-    private void setStatusColor(int color)
-    {
+    private void setStatusColor(int color) {
         status.setBackgroundColor(color);
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_main, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (R.id.action_settings == item.getItemId()) {
+            openSettings();
+            return true;
+        } else {
+            return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/app/src/main/java/keystoretest/com/keystoretest/MainActivity.java
+++ b/app/src/main/java/keystoretest/com/keystoretest/MainActivity.java
@@ -3,6 +3,7 @@ package keystoretest.com.keystoretest;
 import android.app.admin.DevicePolicyManager;
 import android.content.Intent;
 import android.graphics.Color;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
@@ -25,6 +26,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         status = (TextView) findViewById(R.id.status);
+        printDeviceDetails();
     }
 
 
@@ -112,5 +114,15 @@ public class MainActivity extends AppCompatActivity {
         } else {
             return super.onOptionsItemSelected(item);
         }
+    }
+
+    public void printDeviceDetails() {
+        TextView deviceInfo = (TextView) findViewById(R.id.deviceInfo);
+
+        StringBuilder b = new StringBuilder();
+        b.append("DEVICE: ").append(Build.MANUFACTURER).append(" ").append(Build.MODEL).append("\n");
+        b.append("OS: ").append(Build.VERSION.RELEASE).append("-").append(Build.VERSION.SDK_INT);
+
+        deviceInfo.setText(b.toString());
     }
 }

--- a/app/src/main/java/keystoretest/com/keystoretest/Prefs.java
+++ b/app/src/main/java/keystoretest/com/keystoretest/Prefs.java
@@ -1,0 +1,25 @@
+package keystoretest.com.keystoretest;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class Prefs {
+
+    private final SharedPreferences sharedPreferences;
+    private static final String KEY_ENC_REQUIRED = "KEY_ENC_REQUIRED";
+
+    public Prefs(Context context) {
+        sharedPreferences = context.getSharedPreferences("KEYSTORE_TEST.Prefs", Context.MODE_PRIVATE);
+    }
+
+    @SuppressLint("CommitPrefEdits")
+    void setEncryptionRequired(boolean encryptionRequired) {
+        sharedPreferences.edit().putBoolean(KEY_ENC_REQUIRED, encryptionRequired).commit();
+    }
+
+    boolean isEncryptionRequired() {
+        return sharedPreferences.getBoolean(KEY_ENC_REQUIRED, false);
+    }
+
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,4 +37,10 @@
         android:onClick="generateClicked"
         android:text="@string/generate_button" />
 
+    <CheckBox
+        android:id="@+id/generateEncryptedChk"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/encryption_required_chk" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,26 +1,40 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:paddingLeft="@dimen/activity_horizontal_margin"
-                android:paddingRight="@dimen/activity_horizontal_margin"
-                android:paddingTop="@dimen/activity_vertical_margin"
-                android:paddingBottom="@dimen/activity_vertical_margin"
-                android:orientation="vertical"
-                tools:context=".MainActivity">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/deviceInfo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="Device and OS version info" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginBottom="16dp"
+        android:layout_marginTop="16dp"
+        android:background="#C4C4C4"
+        android:paddingEnd="16dp"
+        android:paddingStart="16dp" />
 
     <TextView
         android:id="@+id/status"
-        android:text="@string/hello_world"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        />
+        android:text="@string/hello_world" />
 
     <Button
         android:id="@+id/generateButton"
-        android:text="Generate!"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:onClick="generateClicked"/>
+        android:onClick="generateClicked"
+        android:text="@string/generate_button" />
 
 </LinearLayout>

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -5,5 +5,5 @@
     <item android:id="@+id/action_settings"
           android:title="@string/action_settings"
           android:orderInCategory="100"
-          app:showAsAction="never"/>
+          app:showAsAction="always"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,8 @@
 
     <string name="app_name">KeystoreTest</string>
     <string name="hello_world">Hello world!</string>
-    <string name="action_settings">Open system lock settings</string>
+    <string name="action_settings">sys lock settings</string>
     <string name="generate_button">Generate!</string>
+    <string name="encryption_required_chk">Encryption required</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="app_name">KeystoreTest</string>
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Open system lock settings</string>
+    <string name="generate_button">Generate!</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,6 @@
 
     <string name="app_name">KeystoreTest</string>
     <string name="hello_world">Hello world!</string>
-    <string name="action_settings">Settings</string>
+    <string name="action_settings">Open system lock settings</string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Tue Mar 28 12:07:30 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
I've recently been using this project to expand the tests of the keystore.  I've made a few changes to the KeystoreWipeTest app to aid and speed this up. 

* Checkbox option to setEncrypted (also includes sharedpref based setting to retain the current selection)
* Test steps and blank table in the readme 
* Menu/Action bar button to launch the device lock menu (speeds up testing)
* Added Device and OS details to UI to aid testers recording the correct device/OS. 
* Updated gradle, gradle plugin and target/compile SDK versions to latest. 
 